### PR TITLE
Support using checksums mirrors maintained by asfaload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "md-5",
  "once_cell",
  "predicates",
+ "rand",
  "reqwest",
  "sha1",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3.13.0"
 thiserror = "1.0.64"
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
 url = "2.5.2"
+rand = "0.8.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ struct AsfaloadHost<'a> {
     // /checksums
     prefix: Option<&'a str>,
 }
-static ASFALOAD_HOSTS: Lazy<Vec<AsfaloadHost>> = Lazy::new(|| {
+static ASFALOAD_HOSTS: Lazy<Vec<AsfaloadHost<'_>>> = Lazy::new(|| {
     vec![
         AsfaloadHost {
             host: "gh.checksums.asfaload.com",

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,10 +214,15 @@ fn update_url_asfaload_host(url: &Url) -> Url {
     let chosen_host = ASFALOAD_HOSTS.choose(&mut rand::thread_rng()).unwrap();
     let mut nurl = url.clone();
     let npath = chosen_host
+        // Tke the mirror's prefix
         .prefix
+        // Put the `/` in front of it
         .map(|p| p.to_string() + "/")
+        // And get it out of the option, or the empty string
         .unwrap_or_default()
+        // Put the host in the path
         + &url.host().unwrap().to_string()
+        // Followed by the full original path
         + url.path();
     nurl.set_path(&npath);
     let host_result = nurl.set_host(Some(chosen_host.host));

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,13 +42,19 @@ struct AsfaloadHost<'a> {
     host: &'a str,
     // The prefix to add to the path to the checksums file compared to the original path, eg
     // /checksums
-    prefix: &'a str,
+    prefix: Option<&'a str>,
 }
 static ASFALOAD_HOSTS: Lazy<Vec<AsfaloadHost>> = Lazy::new(|| {
-    vec![AsfaloadHost {
-        host: "asfaload.github.io",
-        prefix: "/checksums",
-    }]
+    vec![
+        AsfaloadHost {
+            host: "asfaload.github.io",
+            prefix: Some("/checksums"),
+        },
+        AsfaloadHost {
+            host: "cf.checksums.asfaload.com",
+            prefix: None,
+        },
+    ]
 });
 static SEARCH: Emoji<'_, '_> = Emoji("🔍", "");
 static FOUND: Emoji<'_, '_> = Emoji("✨", "");
@@ -207,8 +213,12 @@ fn update_url_path(url: &Url, path: &str) -> Url {
 fn update_url_asfaload_host(url: &Url) -> Url {
     let chosen_host = ASFALOAD_HOSTS.choose(&mut rand::thread_rng()).unwrap();
     let mut nurl = url.clone();
-    let npath =
-        chosen_host.prefix.to_string() + "/" + &url.host().unwrap().to_string() + url.path();
+    let npath = chosen_host
+        .prefix
+        .map(|p| p.to_string() + "/")
+        .unwrap_or_default()
+        + &url.host().unwrap().to_string()
+        + url.path();
     nurl.set_path(&npath);
     let host_result = nurl.set_host(Some(chosen_host.host));
     host_result

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,8 @@ struct AsfaloadHost<'a> {
 static ASFALOAD_HOSTS: Lazy<Vec<AsfaloadHost>> = Lazy::new(|| {
     vec![
         AsfaloadHost {
-            host: "asfaload.github.io",
-            prefix: Some("/checksums"),
+            host: "gh.checksums.asfaload.com",
+            prefix: None,
         },
         AsfaloadHost {
             host: "cf.checksums.asfaload.com",

--- a/tests/asfald.rs
+++ b/tests/asfald.rs
@@ -28,7 +28,7 @@ fn file_with_valid_checksum() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -50,7 +50,7 @@ fn file_with_valid_checksum_o() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -77,7 +77,7 @@ fn file_with_valid_checksum_p_url() {
 
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -102,7 +102,7 @@ fn file_with_valid_checksum_p_fullpath() {
 
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -127,7 +127,7 @@ fn file_with_valid_checksum_p_file_pattern() {
 
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -154,7 +154,7 @@ fn file_with_valid_checksum_p_path_pattern() {
 
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -179,7 +179,7 @@ fn file_p_pattern_with_http() {
 
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -221,7 +221,7 @@ fn file_without_checksums_file() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .failure()
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("File\'s checksum is valid !").not())
         .stderr(contains("Unable to fetch checksum file"));
 
@@ -245,7 +245,7 @@ fn file_without_checksums_file_but_force_absent() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("File\'s checksum is valid !").not())
         .stdout(contains(
             "Checksum file not found, but continuing due to --force-absent or --force-invalid flag",
@@ -272,7 +272,7 @@ fn file_without_checksums_file_but_force_invalid() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("File\'s checksum is valid !").not())
         .stdout(contains(
             "Checksum file not found, but continuing due to --force-absent or --force-invalid flag",
@@ -291,7 +291,7 @@ fn file_with_invalid_checksum() {
     cmd.arg(url("/invalid_checksum/the_file.txt"));
     cmd.assert()
         .failure()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is invalid !"));
 }
 
@@ -304,7 +304,7 @@ fn file_with_invalid_checksum_force_absent() {
     cmd.arg("-f");
     cmd.assert()
         .failure()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is invalid !"));
 }
 
@@ -317,7 +317,7 @@ fn file_with_invalid_checksum_force_invalid() {
     cmd.arg("-F");
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is invalid !"))
         .stdout(contains("⚠️⚠️ WARNING: this is insecure, and still downloads file with a checksum present, but invalid! ⚠️⚠️"));
 }
@@ -331,7 +331,7 @@ fn file_with_path_and_valid_checksum() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -346,7 +346,7 @@ fn file_with_binary_indicator() {
     cmd.arg(url("/checksums_with_binary_indicator/the_file.txt"));
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !"))
+        .stdout(contains("Checksum file found at localhost!"))
         .stdout(contains("File\'s checksum is valid !"));
 
     let is_file_pred = is_file();
@@ -372,7 +372,7 @@ fn cli_with_hash_flag() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .success()
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("Using hash passed as argument"))
         .stdout(contains("File\'s checksum is valid !"))
         .stderr(contains("Unable to fetch checksum file").not());
@@ -394,7 +394,7 @@ fn cli_with_hash_flag() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .failure()
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("Using hash passed as argument"))
         .stdout(contains("File\'s checksum is invalid !"))
         .stderr(contains("Unable to fetch checksum file").not());
@@ -413,7 +413,7 @@ fn cli_with_hash_flag() {
     cmd.assert()
         .success()
         .stdout(contains("Using hash passed as argument"))
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("File\'s checksum is valid !"));
     // Check file was downloaded
     assert!(is_file_pred.eval(Path::new(&dir.join("the_file.txt"))));
@@ -432,7 +432,7 @@ fn cli_with_hash_flag() {
     //cmd.spawn().unwrap();
     cmd.assert()
         .failure()
-        .stdout(contains("Checksum file found !").not())
+        .stdout(contains("Checksum file found at localhost!").not())
         .stdout(contains("Using hash passed as argument"))
         .stdout(contains("File\'s checksum is invalid !"))
         .stderr(contains("Unable to fetch checksum file").not());


### PR DESCRIPTION
Currently behind the flag `-a`. Uses mirrors on Github pages and Cloudflare pages.