### PR TITLE
feat: enable lto in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ rand = "0.8.5"
 assert_cmd = "2.0.16"
 predicates = "3.1.2"
 testdir = "0.9.1"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Reduces binary size on linux from 5.3M to 4.3M.
Fixes #53 