### PR TITLE
build: disable windows build until fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       matrix:
         platform:
-          - os: windows
-            name: windows-x64
-            target: x86_64-pc-windows-msvc
-            runs-on: windows-latest
-            command: build
-            extension: .exe
+          #- os: windows
+          #  name: windows-x64
+          #  target: x86_64-pc-windows-msvc
+          #  runs-on: windows-latest
+          #  command: build
+          #  extension: .exe
           - os: macos
             name: apple-arm64
             target: aarch64-apple-darwin


### PR DESCRIPTION
The windows file system does not seem to accept colon in filename. We have file with colon in the name in tests. Even with a sparse-checkout, the windows build fails. So this disables windows builds for now.