### PR TITLE
build: build windows in linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       matrix:
         platform:
-          #- os: windows
-          #  name: windows-x64
-          #  target: x86_64-pc-windows-msvc
-          #  runs-on: windows-latest
-          #  command: build
-          #  extension: .exe
+          - os: windows
+            name: windows-x64
+            target: x86_64-pc-windows-gnu
+            runs-on: ubuntu-latest
+            command: build
+            extension: .exe
           - os: macos
             name: apple-arm64
             target: aarch64-apple-darwin


### PR DESCRIPTION
As we currently cannot checkout the source on windows, we build the windows executable on linux with the GNU tools.